### PR TITLE
Add support for the PowerDNS-Admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ certbot-dns-powerdns
 
 PowerDNS DNS Authenticator plugin for [Certbot](https://certbot.eff.org/).
 
+Compatibility:
+* PowerDNS Authoritative Server API
+* PowerDNS-Admin API
+
 This plugin is built from the ground up and follows the development style and life-cycle
 of other `certbot-dns-*` plugins found in the
 [Official Certbot Repository](https://github.com/certbot/certbot).

--- a/certbot_dns_powerdns/dns_powerdns.py
+++ b/certbot_dns_powerdns/dns_powerdns.py
@@ -84,11 +84,9 @@ class _PowerDNSLexiconClient(dns_common_lexicon.LexiconClient):
         self.provider = powerdns.Provider(config)
 
     def _handle_http_error(self, e, domain_name):
-        if domain_name in str(e) and (
-            # 4.0 and 4.1 compatibility
-            str(e).startswith('422 Client Error: Unprocessable Entity for url:') or
-            # 4.2
-            str(e).startswith('404 Client Error: Not Found for url:')
-            ):
-            return  # Expected errors when zone name guess is wrong
+        # Depending on server and API version, we expect certain error codes while trying
+        # to guess the correct zone name. Ignore.
+        if domain_name in e.response.url and e.response.status_code in [403, 404, 422]:
+            return
+
         return super(_PowerDNSLexiconClient, self)._handle_http_error(e, domain_name)


### PR DESCRIPTION
The PowerDNS-Admin project provides a PowerDNS compatible API that's scoped to allow an API KEY to access only specific, authenticated domains.

The only change needed to support this in certbot-dns-powerdns, is to accept a few new responses when guessing the zone name.

This PR adds support for this, and have been tested with all (3) available access roles from PowerDNS-Admin (User, Operator, Administrator).