### PR TITLE
Do not use wrong DNS Zone

### DIFF
--- a/certbot_dns_powerdns/dns_powerdns.py
+++ b/certbot_dns_powerdns/dns_powerdns.py
@@ -45,6 +45,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             'credentials',
             'PowerDNS credentials file',
             {
+                'zone': 'PowerDNS API zone',
                 'api-url': 'PowerDNS-compatible API FQDN',
                 'api-key': 'PowerDNS-compatible API key (X-API-Key)'
             }
@@ -52,14 +53,15 @@ class Authenticator(dns_common.DNSAuthenticator):
 
     def _perform(self, domain, validation_name, validation):
         self._get_powerdns_client().add_txt_record(
-            domain, validation_name, validation)
+            self.credentials.conf('zone'), validation_name, validation)
 
     def _cleanup(self, domain, validation_name, validation):
         self._get_powerdns_client().del_txt_record(
-            domain, validation_name, validation)
+            self.credentials.conf('zone'), validation_name, validation)
 
     def _get_powerdns_client(self):
         return _PowerDNSLexiconClient(
+            self.credentials.conf('zone'),
             self.credentials.conf('api-url'),
             self.credentials.conf('api-key'),
             self.ttl
@@ -71,12 +73,13 @@ class _PowerDNSLexiconClient(dns_common_lexicon.LexiconClient):
     Encapsulates all communication with the PowerDNS via Lexicon.
     """
 
-    def __init__(self, api_url, api_key, ttl):
+    def __init__(self, zone, api_url, api_key, ttl):
         super(_PowerDNSLexiconClient, self).__init__()
 
         config = dns_common_lexicon.build_lexicon_config('powerdns', {
             'ttl': ttl,
         }, {
+            'zone': zone,
             'auth_token': api_key,
             'pdns_server': api_url,
         })


### PR DESCRIPTION
```plain
Error determining zone identifier for <subdomain>.<zone>: 404 Client Error: NOT FOUND for url: http://<NS>/api/v1/servers/localhost/zones/<subdomain.zone>..
```

See #18

This is the error I got and this fixes. Of course this breaks existing installs since it adds a `zone` configuration item; but I'm also not sure how the plugin could work otherwise? Does PDNS have a "zone guess" functionality that broke or something?

(btw build is failing because of an unrelated issue with linking openssl)