### PR TITLE
Fix Lexicon breaking for subdomains on PowerDNS API 4.8.3

### DIFF
--- a/certbot_dns_powerdns/dns_powerdns.py
+++ b/certbot_dns_powerdns/dns_powerdns.py
@@ -88,7 +88,9 @@ class _PowerDNSLexiconClient(dns_common_lexicon.LexiconClient):
             # 4.0 and 4.1 compatibility
             str(e).startswith('422 Client Error: Unprocessable Entity for url:') or
             # 4.2
-            str(e).startswith('404 Client Error: Not Found for url:')
+            str(e).startswith('404 Client Error: Not Found for url:') or
+            # 4.8.3
+            str(e).startswith('404 Client Error: NOT FOUND for url:')
             ):
             return  # Expected errors when zone name guess is wrong
         return super(_PowerDNSLexiconClient, self)._handle_http_error(e, domain_name)


### PR DESCRIPTION
Fixed DNS Lexicon issue #26 reported by self.